### PR TITLE
fix(#1): Docker installation guide for linux update

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,14 @@ Install [Docker Desktop](https://www.docker.com/get-started/). This includes bot
 - For Linux (Ubuntu/Debian):
 
     ```bash
-    sudo apt-get update && sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    sudo apt-get update
+    sudo apt-get install ca-certificates curl gnupg lsb-release
+    sudo mkdir -m 0755 -p /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    sudo chmod a+r /etc/apt/keyrings/docker.gpg
+    sudo apt-get update
+    sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 - Verify installation:
 


### PR DESCRIPTION
These PR updates  the documentation for installing docker correctly, when OS doesn't have docker repository added.