### PR TITLE
fix(#3): refactor volume for node_modules

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,6 +21,7 @@ services:
       - ./server/.env.development
     volumes:
       - ./server:/app
+      - /app/node_modules
       - ./uploads:/app/uploads
     ports:
       - '3001:3001'
@@ -35,6 +36,7 @@ services:
       - ./client/.env.development
     volumes:
       - ./client:/app
+      - /app/node_modules
       - ./uploads:/app/uploads
     ports:
       - '3000:3000'


### PR DESCRIPTION
This PR fixes the `docker-compose.dev` file as it overwrites installed dependencies on hot reload.